### PR TITLE
[정해성] feat: Input 컴포넌트에 상품명용 크기 추가

### DIFF
--- a/src/components/ui/Input.tsx
+++ b/src/components/ui/Input.tsx
@@ -21,6 +21,12 @@ const inputVariants = cva(
         sm: 'h-[55px] w-[335px] py-3 text-sm font-normal placeholder:text-sm placeholder:font-normal',
         md: 'h-[55px] w-[440px] py-3 text-sm font-normal placeholder:text-sm placeholder:font-normal',
         lg: 'h-[70px] w-[640px] py-4 text-base font-normal placeholder:text-base placeholder:font-normal',
+        'product-sm':
+          'h-[55px] w-[335px] py-3 text-sm font-normal placeholder:text-sm placeholder:font-normal',
+        'product-md':
+          'h-[60px] w-[360px] py-3 text-sm font-normal placeholder:text-sm placeholder:font-normal',
+        'product-lg':
+          'h-[70px] w-[400px] py-4 text-base font-normal placeholder:text-base placeholder:font-normal',
       },
     },
     defaultVariants: {


### PR DESCRIPTION
## 작업 내용
- Input 공용 컴포넌트에 상품명용 크기 추가
- lg, md, sm 3가지 size

## 구현 기능
- [x] 2가지 입력 상태 (Default, Error)
- [x] 3가지 크기 ( product-sm: 335x55, product-md: 360x60 , product-lg: 400x70)

## 사용법과 예시

```import { Input } from '@/components/ui/Input'; ```

```
<Input placeholder='상품명' size='product-lg' />
<Input placeholder='상품명' size='product-md' />
<Input placeholder='상품명' size='product-sm' />
```

<img width="447" height="241" alt="image" src="https://github.com/user-attachments/assets/49aa7957-523d-4bf6-a192-7c879fb51a8a" />
