### PR TITLE
[정해성] feat: TextArea 컴포넌트 구현

### DIFF
--- a/src/components/ui/textarea.tsx
+++ b/src/components/ui/textarea.tsx
@@ -1,0 +1,82 @@
+'use client';
+
+import * as React from 'react';
+import { cva, type VariantProps } from 'class-variance-authority';
+import { cn } from '@/lib/utils';
+
+const textareaVariants = cva(
+  'flex w-full rounded-lg bg-[#252530] px-3 py-3 outline-none placeholder:text-muted-foreground text-[#F1F1F5] transition-[color,box-shadow] resize-none border',
+  {
+    variants: {
+      variant: {
+        default:
+          'border-[#353542] hover:border-[#5097FA] focus-visible:border-[#5097FA] focus-visible:ring-[#5097FA]',
+        error: 'border-[#FF0000] focus-visible:border-[#FF0000] focus-visible:ring-[#FF0000]',
+      },
+      size: {
+        sm: 'h-[120px] w-[295px] text-sm font-normal placeholder:text-sm placeholder:font-normal',
+        md: 'h-[160px] w-[510px] text-sm font-normal placeholder:text-sm placeholder:font-normal',
+        lg: 'h-[160px] w-[540px] text-base font-normal placeholder:text-base placeholder:font-normal',
+      },
+    },
+    defaultVariants: {
+      variant: 'default',
+      size: 'md',
+    },
+  },
+);
+
+export interface TextareaProps
+  extends Omit<React.ComponentProps<'textarea'>, 'size'>,
+    VariantProps<typeof textareaVariants> {
+  maxLength?: number;
+  showCharCount?: boolean;
+}
+
+const Textarea = React.forwardRef<HTMLTextAreaElement, TextareaProps>(
+  (
+    {
+      className,
+      variant = 'default',
+      size = 'md',
+      maxLength = 300,
+      showCharCount = true,
+      ...props
+    },
+    ref,
+  ) => {
+    const [value, setValue] = React.useState('');
+    const charCount = value.length;
+
+    const handleChange = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
+      const newValue = e.target.value;
+      if (newValue.length <= maxLength) {
+        setValue(newValue);
+        props.onChange?.(e);
+      }
+    };
+
+    return (
+      <div className='relative w-fit'>
+        <textarea
+          data-slot='textarea'
+          className={cn(textareaVariants({ variant, size, className }))}
+          ref={ref}
+          value={value}
+          onChange={handleChange}
+          {...props}
+        />
+        {showCharCount && (
+          <div className='absolute bottom-3 right-3 pointer-events-none'>
+            <span className='text-sm font-normal text-[#6E6E82]'>
+              {charCount}/{maxLength}
+            </span>
+          </div>
+        )}
+      </div>
+    );
+  },
+);
+Textarea.displayName = 'Textarea';
+
+export { Textarea, textareaVariants };


### PR DESCRIPTION
## 작업 내용
- 3가지 사이즈 지원 (모바일,테블릿,PC)  (sm: 295x120, md: 510x160, lg: 540x160)
- 300자 제한 및 자동 문자 카운터
- 모달 내 리뷰 작성용으로 최적화

## 사용법과 예시

import { Textarea } from '@/components/ui/textarea';


```
<Textarea placeholder='리뷰를 작성해 주세요' size='lg' />
<Textarea placeholder='리뷰를 작성해 주세요' size='md' />
<Textarea placeholder='리뷰를 작성해 주세요' size='sm' />
```
<img width="568" height="490" alt="image" src="https://github.com/user-attachments/assets/25198530-6722-4acd-9e4f-b6322ff57c1f" />




