### PR TITLE
[정해성] feat: OAuth 카카오톡 구현

### DIFF
--- a/src/app/oauth/callback/kakao/page.tsx
+++ b/src/app/oauth/callback/kakao/page.tsx
@@ -1,0 +1,33 @@
+'use client';
+
+import { useEffect } from 'react';
+import { useRouter, useSearchParams } from 'next/navigation';
+
+export default function KakaoCallbackPage() {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+
+  useEffect(() => {
+    const code = searchParams.get('code');
+
+    if (code) {
+      console.log('카카오 인증 코드:', code);
+      // TODO: 이 코드를 사용해서 액세스 토큰 요청하기
+
+      // 임시로 홈페이지로 리다이렉트
+      router.push('/');
+    } else {
+      // 인증 실패시 로그인 페이지로
+      router.push('/signin');
+    }
+  }, [router, searchParams]);
+
+  return (
+    <div className='flex items-center justify-center min-h-screen bg-[#1C1C22]'>
+      <div className='text-center text-white'>
+        <h2 className='text-xl mb-2'>카카오 로그인 처리 중...</h2>
+        <p className='text-gray-400'>잠시만 기다려주세요.</p>
+      </div>
+    </div>
+  );
+}

--- a/src/app/oauth/callback/page.tsx
+++ b/src/app/oauth/callback/page.tsx
@@ -2,10 +2,12 @@
 
 import { useEffect, useState } from 'react';
 import { useRouter, useSearchParams } from 'next/navigation';
+import { useAuthStore } from '@/lib/stores/authStore';
 
 export default function OAuthCallbackPage() {
   const router = useRouter();
   const searchParams = useSearchParams();
+  const { login } = useAuthStore();
 
   useEffect(() => {
     const code = searchParams.get('code');
@@ -30,6 +32,15 @@ export default function OAuthCallbackPage() {
       if (signInResult) {
         console.log('기존 회원 로그인 성공:', signInResult);
         localStorage.setItem('auth-token', signInResult.accessToken);
+
+        // authStore에 사용자 정보 저장 (전역상태 업데이트)
+        login({
+          id: signInResult.user.id,
+          email: signInResult.user.email,
+          nickname: signInResult.user.nickname,
+          profileImage: signInResult.user.image,
+        });
+
         setLoginResult({ status: 'success' });
         router.push('/');
         return;

--- a/src/app/oauth/callback/page.tsx
+++ b/src/app/oauth/callback/page.tsx
@@ -1,0 +1,134 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { useRouter, useSearchParams } from 'next/navigation';
+
+export default function OAuthCallbackPage() {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+
+  useEffect(() => {
+    const code = searchParams.get('code');
+
+    if (code) {
+      console.log('카카오 인증 코드:', code);
+      handleKakaoLogin(code);
+    } else {
+      router.push('/signin');
+    }
+  }, [router, searchParams]);
+
+  const [loginResult, setLoginResult] = useState<{
+    status: 'loading' | 'success' | 'needSignup' | 'error';
+    error?: string;
+  }>({ status: 'loading' });
+
+  const handleKakaoLogin = async (code: string) => {
+    try {
+      // 로그인 시도 (기존 회원인지 확인)
+      const signInResult = await trySignIn(code);
+      if (signInResult) {
+        console.log('기존 회원 로그인 성공:', signInResult);
+        localStorage.setItem('auth-token', signInResult.accessToken);
+        setLoginResult({ status: 'success' });
+        router.push('/');
+        return;
+      }
+
+      // 로그인 실패시 회원가입 버튼 표시
+      setLoginResult({ status: 'needSignup' });
+    } catch (error) {
+      console.error('소셜 로그인 처리 중 오류:', error);
+      setLoginResult({ status: 'error', error: '로그인 처리 중 오류가 발생했습니다.' });
+    }
+  };
+
+  const handleSignupClick = () => {
+    // 새로운 인가코드를 받기 위해 카카오 회원가입 OAuth URL로 리다이렉트
+    const clientId = process.env.NEXT_PUBLIC_KAKAO_CLIENT_ID;
+    const redirectUri = process.env.NEXT_PUBLIC_KAKAO_SIGNUP_REDIRECT_URI;
+
+    window.location.href = `https://kauth.kakao.com/oauth/authorize?client_id=${clientId}&redirect_uri=${redirectUri}&response_type=code`;
+  };
+
+  const trySignIn = async (code: string) => {
+    try {
+      const requestData = {
+        redirectUri: process.env.NEXT_PUBLIC_KAKAO_REDIRECT_URI,
+        token: code, // 인가코드를 token 필드에
+      };
+      console.log('로그인 요청 데이터:', requestData);
+
+      const response = await fetch('https://mogazoa-api.vercel.app/16-5/auth/signIn/kakao', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify(requestData),
+      });
+
+      if (response.ok) {
+        return await response.json();
+      } else {
+        const errorData = await response.json().catch(() => null);
+        console.error('로그인 실패:', response.status, errorData);
+      }
+
+      return null;
+    } catch (error) {
+      console.error('로그인 시도 실패:', error);
+      return null;
+    }
+  };
+
+  if (loginResult.status === 'loading') {
+    return (
+      <div className='flex items-center justify-center min-h-screen bg-[#1C1C22]'>
+        <div className='text-center text-white'>
+          <h2 className='text-xl mb-2'>카카오 로그인 처리 중...</h2>
+          <p className='text-gray-400'>잠시만 기다려주세요.</p>
+        </div>
+      </div>
+    );
+  }
+
+  if (loginResult.status === 'needSignup') {
+    return (
+      <div className='flex items-center justify-center min-h-screen bg-[#1C1C22]'>
+        <div className='text-center text-white'>
+          <h2 className='text-2xl font-bold mb-4'>카카오 간편 회원가입</h2>
+          <p className='text-gray-400 mb-8'>
+            등록되지 않은 사용자입니다.
+            <br />
+            간편하게 회원가입을 진행해보세요!
+          </p>
+          <button
+            onClick={handleSignupClick}
+            className='bg-yellow-400 hover:bg-yellow-500 text-black font-bold py-3 px-8 rounded-lg text-lg transition duration-200'
+          >
+            카카오로 회원가입하기
+          </button>
+        </div>
+      </div>
+    );
+  }
+
+  if (loginResult.status === 'error') {
+    return (
+      <div className='flex items-center justify-center min-h-screen bg-[#1C1C22]'>
+        <div className='text-center text-white'>
+          <h2 className='text-xl mb-2'>오류가 발생했습니다</h2>
+          <p className='text-gray-400 mb-4'>{loginResult.error}</p>
+          <button
+            onClick={() => router.push('/signin')}
+            className='bg-blue-600 hover:bg-blue-700 text-white px-6 py-2 rounded-lg'
+          >
+            로그인 페이지로 돌아가기
+          </button>
+        </div>
+      </div>
+    );
+  }
+
+  return null;
+}

--- a/src/app/oauth/signup/kakao/page.tsx
+++ b/src/app/oauth/signup/kakao/page.tsx
@@ -1,0 +1,95 @@
+'use client';
+
+import { useState } from 'react';
+import { useRouter, useSearchParams } from 'next/navigation';
+import { Input } from '@/components/ui/Input';
+import { Button } from '@/components/ui/button';
+
+export default function KakaoSignupCallbackPage() {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  const [nickname, setNickname] = useState('');
+  const [isLoading, setIsLoading] = useState(false);
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+
+    if (!nickname.trim()) {
+      alert('닉네임을 입력해주세요.');
+      return;
+    }
+
+    const code = searchParams.get('code');
+    if (!code) {
+      alert('인가 코드가 없습니다. 다시 로그인해주세요.');
+      router.push('/signin');
+      return;
+    }
+
+    setIsLoading(true);
+
+    try {
+      console.log('회원가입 요청:', {
+        nickname,
+        redirectUri: process.env.NEXT_PUBLIC_KAKAO_SIGNUP_REDIRECT_URI,
+        token: code,
+      });
+
+      const response = await fetch('https://mogazoa-api.vercel.app/16-5/auth/signUp/kakao', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({
+          nickname: nickname,
+          redirectUri: process.env.NEXT_PUBLIC_KAKAO_SIGNUP_REDIRECT_URI,
+          token: code,
+        }),
+      });
+
+      if (response.ok) {
+        const data = await response.json();
+        console.log('회원가입 성공:', data);
+        localStorage.setItem('auth-token', data.accessToken);
+        router.push('/');
+      } else {
+        const errorData = await response.json().catch(() => null);
+        console.error('회원가입 실패:', errorData);
+        alert(errorData?.message || '회원가입에 실패했습니다.');
+      }
+    } catch (error) {
+      console.error('회원가입 오류:', error);
+      alert('회원가입에 실패했습니다.');
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  return (
+    <div className='min-h-screen bg-[#1C1C22] flex items-center justify-center px-4'>
+      <div>
+        <form onSubmit={handleSubmit} className='space-y-6'>
+          <Input
+            id='nickname'
+            type='text'
+            value={nickname}
+            onChange={(e) => setNickname(e.target.value)}
+            label='닉네임'
+            placeholder='닉네임을 입력해주세요'
+            disabled={isLoading}
+            size='lg'
+          />
+
+          <Button
+            type='submit'
+            disabled={isLoading || !nickname.trim()}
+            variant='primary'
+            size='lg'
+          >
+            {isLoading ? '처리중...' : '가입하기'}
+          </Button>
+        </form>
+      </div>
+    </div>
+  );
+}

--- a/src/app/signin/components/SocialButtons.tsx
+++ b/src/app/signin/components/SocialButtons.tsx
@@ -12,35 +12,25 @@ export default function SocialButtons() {
 
   const handleSocialLogin = async (provider: SocialProvider) => {
     try {
-      // TODO: 실제 소셜 로그인 API 호출
+      if (provider === 'kakao') {
+        const clientId = process.env.NEXT_PUBLIC_KAKAO_CLIENT_ID;
+        const redirectUri = process.env.NEXT_PUBLIC_KAKAO_REDIRECT_URI;
+
+        window.location.href = `https://kauth.kakao.com/oauth/authorize?client_id=${clientId}&redirect_uri=${redirectUri}&response_type=code`;
+        return;
+      }
+
+      // TODO: 구글 소셜 로그인 API 호출
       console.log(`${provider} 로그인 시도`);
 
-      // 임시: 소셜 로그인 시뮬레이션
+      // 임시: 소셜 로그인 시뮬레이션 (구글용)
       const loginResult = {
         success: true,
         isNewUser: true, // true면 간편 회원가입 화면으로
       };
       if (loginResult.success) {
-        console.log('provider:', provider);
-        console.log('isNewUser:', loginResult.isNewUser);
-        console.log('조건 체크:', loginResult.isNewUser && provider === 'kakao');
-
-        if (loginResult.isNewUser && provider === 'kakao') {
-          console.log('카카오 간편가입으로 이동');
-          router.push(`/oauth/signup/${provider}`);
-        } else {
-          console.log('홈으로 이동');
-          router.push('/');
-        }
-      }
-      if (loginResult.success) {
-        if (loginResult.isNewUser && provider === 'kakao') {
-          // 신규 유저이고 카카오인 경우 간편 회원가입으로
-          router.push(`/oauth/signup/${provider}`);
-        } else {
-          // 기존 유저이거나 구글인 경우 홈으로
-          router.push('/');
-        }
+        console.log('구글 로그인 성공, 홈으로 이동');
+        router.push('/');
       } else {
         // 소셜 로그인 실패
         alert('소셜 로그인에 실패했습니다.');

--- a/src/app/signup/kakao/page.tsx
+++ b/src/app/signup/kakao/page.tsx
@@ -1,0 +1,93 @@
+'use client';
+
+import { useState } from 'react';
+import { useRouter, useSearchParams } from 'next/navigation';
+
+export default function KakaoSignupPage() {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  const [nickname, setNickname] = useState('');
+  const [isLoading, setIsLoading] = useState(false);
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+
+    if (!nickname.trim()) {
+      alert('닉네임을 입력해주세요.');
+      return;
+    }
+
+    const code = searchParams.get('code');
+    if (!code) {
+      alert('인가 코드가 없습니다. 다시 로그인해주세요.');
+      router.push('/signin');
+      return;
+    }
+
+    setIsLoading(true);
+
+    try {
+      const response = await fetch('https://mogazoa-api.vercel.app/16-5/auth/signUp/kakao', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({
+          nickname: nickname,
+          redirectUri: process.env.NEXT_PUBLIC_KAKAO_REDIRECT_URI,
+          token: code,
+        }),
+      });
+
+      if (response.ok) {
+        const data = await response.json();
+        localStorage.setItem('auth-token', data.accessToken);
+        router.push('/');
+      } else {
+        const errorData = await response.json().catch(() => null);
+        alert(errorData?.message || '회원가입에 실패했습니다.');
+      }
+    } catch (error) {
+      console.error('회원가입 실패:', error);
+      alert('회원가입에 실패했습니다.');
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  return (
+    <div className='min-h-screen bg-[#1C1C22] flex items-center justify-center px-4'>
+      <div className='w-full max-w-md'>
+        <div className='text-center mb-8'>
+          <h1 className='text-2xl font-bold text-white mb-2'>카카오 간편 회원가입</h1>
+          <p className='text-gray-400'>사용하실 닉네임을 입력해주세요</p>
+        </div>
+
+        <form onSubmit={handleSubmit} className='space-y-6'>
+          <div>
+            <label htmlFor='nickname' className='block text-sm font-medium text-white mb-2'>
+              닉네임
+            </label>
+            <input
+              id='nickname'
+              type='text'
+              value={nickname}
+              onChange={(e) => setNickname(e.target.value)}
+              className='w-full px-4 py-3 bg-[#252530] border border-[#353542] rounded-lg text-white placeholder-gray-500 focus:outline-none focus:ring-2 focus:ring-blue-500'
+              placeholder='닉네임을 입력해주세요'
+              disabled={isLoading}
+            />
+          </div>
+
+          <button
+            type='submit'
+            disabled={isLoading || !nickname.trim()}
+            className='w-full bg-blue-600 hover:bg-blue-700 disabled:bg-gray-600 text-white font-medium py-3 px-4 rounded-lg transition duration-200'
+          >
+            {isLoading ? '처리중...' : '가입하기'}
+          </button>
+        </form>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## 작업 내용
  - 카카오 소셜 로그인 버튼 구현 (`SocialButtons.tsx`)
  - OAuth 콜백 페이지 구현 (`/oauth/callback`)
  - 신규 사용자용 회원가입 콜백 페이지 구현 (`/oauth/signup/kakao`)
  - 닉네임 입력 페이지 구현 (Input/Button 컴포넌트 사용)
  - 서버 API 연동 (기존 회원 로그인 / 신규 회원 가입)

  ## 구현 플로우
  ### 기존 사용자
  1. 소셜 로그인 → 카카오 인증 → 서버 로그인 성공 → 홈 이동

  ### 신규 사용자
  1. 소셜 로그인 → 카카오 인증 → 서버 로그인 실패 (403)
  2. 회원가입 버튼 표시 → 새로운 OAuth 인증
  3. 닉네임 입력 → 회원가입 완료 → 홈 이동

 ## 테스트
  - [x] 기존 계정으로 카카오 로그인 테스트
  - [x] 신규 계정으로 카카오 회원가입 테스트
  - [x] UI 컴포넌트 정상 동작 확인